### PR TITLE
Improve installed apps retrieval

### DIFF
--- a/PowerShell-PC-Inventory.ps1
+++ b/PowerShell-PC-Inventory.ps1
@@ -114,6 +114,7 @@ if ($checkInstalledApps -eq 1) {
   foreach ($App in $Apps) {
     $appslist += "$($App.DisplayName) $($App.DisplayVersion)`n"
   }
+  $appslist
 } else {
   $appsList = "N/A"
 }


### PR DESCRIPTION
Retrieves both 32 and 64bit apps as well as user profile apps for all users (will only retrieve current user if run as a limited user instead of admin/system). Also sorts and de-duplicates the app list.