### PR TITLE
Remove unused $OSBuild variable code

### DIFF
--- a/PowerShell-PC-Inventory.ps1
+++ b/PowerShell-PC-Inventory.ps1
@@ -139,9 +139,6 @@ $GPU1 = GetGPUInfo | Select-Object -Index 1
 # OS
 $OS = Get-CimInstance -Class Win32_OperatingSystem
 
-# OS Build
-$OSBuild = (Get-Item "HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion").GetValue('ReleaseID')
-
 # Up time
 # Get the last boot time of the system
 $lastBootTime = (Get-CimInstance -ClassName Win32_OperatingSystem).LastBootUpTime


### PR DESCRIPTION
Removed the retrieval of the OS Build from the registry. It just returns '2009' for all recent versions of Windows anyway so not useful, which is probably why it's no longer used anywhere in the script.